### PR TITLE
FIX possible detrimental tf api usage

### DIFF
--- a/tools/restore_model.py
+++ b/tools/restore_model.py
@@ -25,7 +25,11 @@ def get_restorer():
         if RESTORE_FROM_RPN:
             print('___restore from rpn___')
             model_variables = slim.get_model_variables()
-            restore_variables = [var for var in model_variables if not var.name.startswith('Fast_Rcnn')] + [slim.get_or_create_global_step()]
+            if(tf.__version__.startswith("1.") and int(tf.__version__.split(".")[1])<=3) or tf.__version__.startswith("0."):
+                ### for tf version <=1.3.0
+                restore_variables = [var for var in model_variables if not var.name.startswith('Fast_Rcnn')] + [slim.get_or_create_global_step()]
+            else: ### for tf version >=1.4.0
+                restore_variables = [var for var in model_variables if not var.name.startswith('Fast_Rcnn')] + [tf.train.get_or_create_global_step()]
             for var in restore_variables:
                 print(var.name)
             restorer = tf.train.Saver(restore_variables)

--- a/tools/train.py
+++ b/tools/train.py
@@ -137,7 +137,11 @@ def train():
         # train
         total_loss = slim.losses.get_total_loss()
 
-        global_step = slim.get_or_create_global_step()
+        if(tf.__version__.startswith("1.") and int(tf.__version__.split(".")[1])<=3) or tf.__version__.startswith("0."):
+            ### for tf version <=1.3.0
+            global_step = slim.get_or_create_global_step()
+        else: ### for tf version >=1.4.0
+            global_step = tf.train.get_or_create_global_step()
 
         lr = tf.train.piecewise_constant(global_step,
                                          boundaries=[np.int64(20000), np.int64(40000)],

--- a/tools/train1.py
+++ b/tools/train1.py
@@ -148,8 +148,11 @@ def train():
 
         # train
         total_loss = slim.losses.get_total_loss()
-
-        global_step = slim.get_or_create_global_step()
+        if(tf.__version__.startswith("1.") and int(tf.__version__.split(".")[1])<=3) or tf.__version__.startswith("0."):
+            ### for tf version <=1.3.0
+            global_step = slim.get_or_create_global_step()
+        else: ### for tf version >=1.4.0
+            global_step = tf.train.get_or_create_global_step()
 
         lr = tf.train.piecewise_constant(global_step,
                                          boundaries=[np.int64(20000), np.int64(40000)],


### PR DESCRIPTION
Dear developers,

When I use your project, I encountered some usage of deprecated TensorFlow APIs which might be harmful in the future. So I help you to modify it as below:

`tf.contrib.slim.get_model_variables` has been deprecated in tf v1.4.0. It's better to replace it will `tf.train.get_or_create_global_step`.

@yangJirui @yangxue0827 
Hope you could accept my advice and look forward to your reply! 😃 